### PR TITLE
feat: Implementação do Relatório Financeiro em PDF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>spring-boot-starter-webmvc-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf</artifactId>
+      <version>1.3.32</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/necklogic/sepapi/controller/ReportController.java
+++ b/src/main/java/com/necklogic/sepapi/controller/ReportController.java
@@ -42,4 +42,21 @@ public class ReportController {
                 .headers(headers)
                 .body(pdfBytes);
     }
+
+    @GetMapping("/finance")
+    public ResponseEntity<byte[]> getFinanceReport(
+            @RequestParam UUID professorId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+
+        byte[] pdfBytes = reportService.generateFinanceReport(professorId, start, end);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        headers.setContentDispositionFormData("attachment", "relatorio_financeiro_" + professorId + ".pdf");
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(pdfBytes);
+    }
 }

--- a/src/main/java/com/necklogic/sepapi/service/ReportService.java
+++ b/src/main/java/com/necklogic/sepapi/service/ReportService.java
@@ -2,9 +2,12 @@ package com.necklogic.sepapi.service;
 
 import com.lowagie.text.*;
 import com.lowagie.text.pdf.*;
+import com.necklogic.sepapi.model.Finance;
 import com.necklogic.sepapi.model.Lesson;
 import com.necklogic.sepapi.model.Student;
+import com.necklogic.sepapi.model.enums.PaymentStatus;
 import com.necklogic.sepapi.model.enums.LessonStatus;
+import com.necklogic.sepapi.repository.FinanceRepository;
 import com.necklogic.sepapi.repository.LessonRepository;
 import com.necklogic.sepapi.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -24,6 +29,7 @@ public class ReportService {
 
     private final StudentRepository studentRepository;
     private final LessonRepository lessonRepository;
+    private final FinanceRepository financeRepository;
 
     public byte[] generateStudentReport(UUID studentId, UUID professorId, LocalDateTime start, LocalDateTime end) {
         Student student = studentRepository.findByIdAndProfessorId(studentId, professorId)
@@ -104,5 +110,86 @@ public class ReportService {
             case COMPLETED -> "Concluída";
             case CANCELED -> "Cancelada/Falta";
         };
+    }
+
+    public byte[] generateFinanceReport(UUID professorId, LocalDate start, LocalDate end) {
+        
+        List<Finance> finances = financeRepository.findAllByProfessorIdAndDueDateBetweenOrderByDueDateDesc(professorId, start, end);
+
+        String professorIdentifier = professorId.toString().substring(0, 8) + "...";
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4);
+            PdfWriter.getInstance(document, baos);
+            document.open();
+
+            buildFinanceHeader(document, professorIdentifier, start, end);
+            buildFinanceMetrics(document, finances);
+            buildFinanceTable(document, finances);
+
+            document.close();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error generating Finance PDF");
+        }
+    }
+
+    private void buildFinanceHeader(Document document, String professorName, LocalDate start, LocalDate end) throws DocumentException {
+        Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18);
+        Paragraph title = new Paragraph("Relatório Financeiro", titleFont);
+        title.setAlignment(Element.ALIGN_CENTER);
+        title.setSpacingAfter(20);
+        document.add(title);
+
+        Font infoFont = FontFactory.getFont(FontFactory.HELVETICA, 12);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        document.add(new Paragraph("Professor (ID): " + professorName, infoFont));
+        document.add(new Paragraph("Período: " + start.format(formatter) + " a " + end.format(formatter), infoFont));
+        document.add(new Paragraph("\n"));
+    }
+
+    private void buildFinanceMetrics(Document document, List<Finance> finances) throws DocumentException {
+        BigDecimal totalPaid = BigDecimal.ZERO;
+        BigDecimal totalOverdue = BigDecimal.ZERO;
+
+        for (Finance finance : finances) {
+            if (finance.getStatus() == PaymentStatus.PAID) {
+                totalPaid = totalPaid.add(finance.getAmount());
+            } else if (finance.getStatus() == PaymentStatus.OVERDUE) {
+                totalOverdue = totalOverdue.add(finance.getAmount());
+            }
+        }
+
+        Font metricsFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12);
+        document.add(new Paragraph(String.format("Total Recebido (PAID): R$ %s | Inadimplência (OVERDUE): R$ %s", 
+                totalPaid.toString(), totalOverdue.toString()), metricsFont));
+        document.add(new Paragraph("\n"));
+    }
+
+    private void buildFinanceTable(Document document, List<Finance> finances) throws DocumentException {
+        PdfPTable table = new PdfPTable(4);
+        table.setWidthPercentage(100);
+        table.setWidths(new float[]{2f, 4f, 2f, 2f});
+
+        Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 11);
+        table.addCell(new PdfPCell(new Phrase("Vencimento", headerFont)));
+        table.addCell(new PdfPCell(new Phrase("Descrição", headerFont)));
+        table.addCell(new PdfPCell(new Phrase("Valor (R$)", headerFont)));
+        table.addCell(new PdfPCell(new Phrase("Status", headerFont)));
+
+        Font cellFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+        for (Finance finance : finances) {
+            table.addCell(new PdfPCell(new Phrase(finance.getDueDate().format(formatter), cellFont)));
+
+            String description = finance.getDescription() != null ? finance.getDescription() : "-";
+            table.addCell(new PdfPCell(new Phrase(description, cellFont)));
+            
+            table.addCell(new PdfPCell(new Phrase(finance.getAmount().toString(), cellFont)));
+            table.addCell(new PdfPCell(new Phrase(finance.getStatus().name(), cellFont)));
+        }
+
+        document.add(table);
     }
 }


### PR DESCRIPTION
Arquivo ReportService.java: Desenvolver o método generateFinanceReport(UUID professorId, LocalDateTime start, LocalDateTime end).

    Estrutura do PDF: Utilizar a biblioteca iText/OpenPDF para criar um documento contendo: Cabeçalho com o nome do professor e período; Uma seção de métricas com o balanço financeiro (Soma de status PAID vs OVERDUE); Uma tabela com 4 colunas listando os lançamentos (Data de Vencimento, Descrição, Valor e Status).

    Arquivo ReportController.java: Criar o endpoint GET /api/reports/finance retornando byte[] com o MediaType.APPLICATION_PDF.